### PR TITLE
macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,14 @@
 *.d
 *.so
 *.so.*
+*.dylib
+*.dylib.*
 *.pyc
 cscope*
 *_generated.h
 test/test1
+test/test-parser
 test/*.got
 test/vnlog_fields_generated*.h
+mrbuild
+mrbuild/

--- a/vnlog-parser.c
+++ b/vnlog-parser.c
@@ -193,7 +193,7 @@ vnlog_parser_result_t read_line(vnlog_parser_t* ctx, FILE* fp)
 }
 
 #ifdef __APPLE__
-// tdestry is a nonstandard extension not present in Apple's libc, but it is easy to redefine
+// tdestroy is a nonstandard extension not present in Apple's libc, but it is easy to redefine
 
 static void tdestroy_recurse(node_t *root, void (*freefct)(void *))
 {
@@ -211,7 +211,7 @@ static void tdestroy_recurse(node_t *root, void (*freefct)(void *))
     free(root);
 }
 
-void tdestroy(void *root, void (*freefct)(void *))
+static void tdestroy(void *root, void (*freefct)(void *))
 {
     if (root == NULL)
     {


### PR DESCRIPTION
The function `tdestroy` is not present in Apple's implementation of `libc`, but the internal type `node_t` used for the tree search routines is accessible. This reimplements `tdestroy` for Apple platforms. The `.gitignore` file was also updated with generated and local-only files.